### PR TITLE
参加ページから遷移してログインした場合の処理 #10

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,5 +11,4 @@ class ApplicationController < ActionController::Base
   def after_sign_in_path_for(resource) 
     lists_path
   end
-
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -6,6 +6,7 @@ class Users::SessionsController < Devise::SessionsController
   # GET /resource/sign_in
   def new
     super
+    session[:previous_url] = request.referer
   end
 
   # POST /resource/sign_in
@@ -14,7 +15,11 @@ class Users::SessionsController < Devise::SessionsController
     set_flash_message!(:notice, :signed_in)
     sign_in(resource_name, resource)
     yield resource if block_given?
-    respond_with resource, location: after_sign_in_path_for(resource)
+    if session[:previous_url].include?("select")
+      redirect_to session[:previous_url]
+    else
+      redirect_to lists_path
+    end
   end
 
   # DELETE /resource/sign_out
@@ -29,4 +34,6 @@ class Users::SessionsController < Devise::SessionsController
   def configure_sign_in_params
     devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
   end
+
+
 end

--- a/app/views/groups/select.html.erb
+++ b/app/views/groups/select.html.erb
@@ -36,6 +36,8 @@
 <%= form_with model: @select_list, url: {controller: 'groups', action: 'join'}, class:"share_form", local: true do |f| %>
   <% if current_user == nil %>
     <%= link_to "まずはログインしよう！", new_user_session_path %>
+  <% elsif @members.any? { |m| m == current_user } %>
+    <%= link_to "グループページへ", group_path(@group) %>
   <% else %>
     <% if @list_id.present? %>
       <div class="share_list">


### PR DESCRIPTION
ログインしていないユーザーが参加ページ(ここではurlAとする)からログインページへ遷移しログインした場合、urlAに戻す処理を追加
これによりLineで共有したURLから参加した未ログインのユーザーもログイン後にわざわざURLで参加グループを検索しなくていい。
close #10