### PR TITLE
list_controllerのnewアクションとcreateアクションの日本語化など #94

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -150,7 +150,7 @@ html {
   padding: 0px;
   border: 0px;
   margin-bottom: 0px;
-  top: 10%;
+  top: 20%;
   left: 50%;
   transform: translate(-50%, -50%);
   -webkit-transform: translate(-50%, -50%);

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -4,25 +4,23 @@ class ListsController < ApplicationController
   require 'rspotify'
   require 'open-uri'
 
-  def new
-    @list = current_user.lists.build
-  end
-
-  def create
-    @list = current_user.lists.build(list_params)
-    if @list.save
-      redirect_to list_path(@list.id)
-      flash[:success] = 'リストを作成しました'
-    else
-      flash.now['alert'] = ' リストが作成できませんでした'
-      render :new
-    end
-  end
-
   def index
     @lists = List.user_lists_get(current_user)
     @songs = Song.where(list_id: @lists.ids)
     @tile = []
+  end
+
+  def new
+    @list = List.new
+  end
+
+  def create
+    @list = current_user.lists.new(list_params)
+    if @list.save
+      redirect_to list_path(@list.id), success: t('.success')
+    else
+      render :new
+    end
   end
 
   def show

--- a/app/views/lists/_form.html.erb
+++ b/app/views/lists/_form.html.erb
@@ -2,6 +2,6 @@
   <div class="form-group">
     <%= f.text_field :name, class: 'form validate[required]', placeholder:"リスト名(20字以内)" %>
     <%= render 'shared/error_messages_model', model: f.object %>
-    <%= f.submit "登録", class: 'btn btn-primary register' %>
+    <%= f.submit t("defaults.new"), class: 'btn btn-primary register' %>
   </div>
 <% end %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,99 +1,102 @@
 ja:
   defaults:
-    login: 'ログイン'
-    register: '無料新規登録'
-    logout: 'ログアウト'
-    mypage: 'マイページ'
-    group_list: 'グループ一覧'
-    list_index: 'リスト一覧'
-    group_name: 'グループ名'
-    make_list: 'リスト作成'
-    list_name: 'リスト名'
-    make: '作成'
-    destroy: '削除'
-    change: '設定を保存'
-    edit: '編集'
-    forget_password: 'パスワードを忘れた方'
-    new_user: 'はじめての方はこちら'
-    new: '登録'
-    privacy: 'プライバシーポリシー'
-    about: '利用規約'
-    question: 'お問い合わせ'
-    questions: 'よくある質問'
+    login: "ログイン"
+    register: "無料新規登録"
+    logout: "ログアウト"
+    mypage: "マイページ"
+    group_list: "グループ一覧"
+    list_index: "リスト一覧"
+    group_name: "グループ名"
+    make_list: "リスト作成"
+    list_name: "リスト名"
+    make: "作成"
+    destroy: "削除"
+    change: "設定を保存"
+    edit: "編集"
+    forget_password: "パスワードを忘れた方"
+    new_user: "はじめての方はこちら"
+    new: "登録"
+    privacy: "プライバシーポリシー"
+    about: "利用規約"
+    question: "お問い合わせ"
+    questions: "よくある質問"
   devise:
-    login_success: 'ログインしました'
-    login_fail: 'ログインに失敗しました'
-    logout_success: 'ログアウトしました'
-    new_success: 'KARALISへようこそ'
-    new_fail: 'ユーザー登録に失敗しました'
-    password_title: 'パスワード再設定'
+    login_success: "ログインしました"
+    login_fail: "ログインに失敗しました"
+    logout_success: "ログアウトしました"
+    new_success: "KARALISへようこそ"
+    new_fail: "ユーザー登録に失敗しました"
+    password_title: "パスワード再設定"
   users:
     new:
-      title: 'ユーザー登録'
-      to_login_page: 'ログインページへ'
+      title: "ユーザー登録"
+      to_login_page: "ログインページへ"
   lists:
     index:
-      title: 'ホーム'
-      new_list: 'リスト作成へ'
-      joined_group: 'グループ一覧'
-      not_list: 'リストがありません'
+      title: "ホーム"
+      new_list: "リスト作成へ"
+      joined_group: "グループ一覧"
+      not_list: "リストがありません"
+    create:
+      success: "リストを作成しました"
+      fail: "リストが作成できませんでした"
     new:
-      title: '新規リスト作成'
+      title: "新規リスト作成"
     show:
-      title: 'リスト詳細'
-      change_list_name: 'リスト名を変更'
-      add_song: '曲を追加'
-      back_to_group: 'グループに戻る'
-      delete_list: 'リストを削除'
+      title: "リスト詳細"
+      change_list_name: "リスト名を変更"
+      add_song: "曲を追加"
+      back_to_group: "グループに戻る"
+      delete_list: "リストを削除"
     edit:
-      title: 'リスト名変更'
-      back_list: 'リストへ戻る'
+      title: "リスト名変更"
+      back_list: "リストへ戻る"
   songs:
     new:
-      title: '曲検索'
-      search: '検索'
-      search_song: '曲を検索する'
-      result: '検索結果'
+      title: "曲検索"
+      search: "検索"
+      search_song: "曲を検索する"
+      result: "検索結果"
   groups:
     index:
-      title: 'グループ一覧'
-      new_group: 'グループ作成'
-      not_group: 'グループがありません'
+      title: "グループ一覧"
+      new_group: "グループ作成"
+      not_group: "グループがありません"
     new:
-      title: '新規グループ作成'
+      title: "新規グループ作成"
     show:
-      title: 'グループ詳細'
-      leave: '退会する'
-      delete: 'グループを削除する'
-      description: 'このグループについて'
+      title: "グループ詳細"
+      leave: "退会する"
+      delete: "グループを削除する"
+      description: "このグループについて"
       member: "メンバー"
     edit:
-      title: 'グループ名変更'
-      back_group: 'グループに戻る'
+      title: "グループ名変更"
+      back_group: "グループに戻る"
     select:
-      title: '参加確認ページ'
-      invite_group: '招待されているグループ'
-      description: 'このグループについて'
-      select_share_list: '共有リストを選択'
-      not_select_share_list: '共有するリストがまだありません'
-      join: '参加する'
-      current_member: '参加しているメンバー'
+      title: "参加確認ページ"
+      invite_group: "招待されているグループ"
+      description: "このグループについて"
+      select_share_list: "共有リストを選択"
+      not_select_share_list: "共有するリストがまだありません"
+      join: "参加する"
+      current_member: "参加しているメンバー"
   profiles:
     show:
-      title: 'プロフィール'
-      made_list: '作ったリスト'
-      joing_group: '所属グループ'
+      title: "プロフィール"
+      made_list: "作ったリスト"
+      joing_group: "所属グループ"
     edit:
-      title: 'プロフィール編集'
-      not_change: '変更せずに戻る'
+      title: "プロフィール編集"
+      not_change: "変更せずに戻る"
   list_groups:
     edit:
-      title: '共有リスト選択'
-      select_share_list: '共有リストを選択'
-      not_select_share_list: '共有するリストがまだありません'
-      not_update: '更新せずに戻る'
+      title: "共有リスト選択"
+      select_share_list: "共有リストを選択"
+      not_select_share_list: "共有するリストがまだありません"
+      not_update: "更新せずに戻る"
     new:
-      title: '共有リスト登録'
-      not_registration: '登録せずに戻る'
-      not_select_share_list: '共有するリストがまだありません'
-      select_share_list: '共有リストを選択'
+      title: "共有リスト登録"
+      not_registration: "登録せずに戻る"
+      not_select_share_list: "共有するリストがまだありません"
+      select_share_list: "共有リストを選択"


### PR DESCRIPTION
why
- listコントローラのnewアクションとcreateアクションを見やすくするため

what
- buildメソッドをnewメソッドに変更
- フラッシュメッセージの日本語化
