### PR TITLE
参加日を正しく表示 #98

### DIFF
--- a/app/views/groups/_member.html.erb
+++ b/app/views/groups/_member.html.erb
@@ -10,7 +10,7 @@
   <% @members.zip(@group_user).each do |member, group_user| %>
     <tr class="white_text">
     <td scope="row"><%= member.name %></td>
-    <td><%= show_date(@group.created_at)  %></td>
+    <td><%= show_date(group_user.created_at)  %></td>
     <% @list.each do |list| %>
       <% if member.id == list.user_id %>
           <td><%= link_to list.name,list_path(list) %>


### PR DESCRIPTION
## 変更の概要

* グループにユーザーが参加した日付を正しく表示
*
## なぜこの変更をするのか

* 前段階では参加日がグループ作成日となっており、後から参加したユーザーの参加日も全て同じ日付になってしまっていた。

## やったこと

* [x] Groupから取得していた情報をGroupUserから取得
